### PR TITLE
Use the official TeXLive image, with moving tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fredqi/texlive:academic
+FROM texlive/texlive:latest
 
 COPY entrypoint.sh /usr/bin/
 


### PR DESCRIPTION
Advantages:
- A bigger set of image maintainers (I'd guess fredqi is just one person)
- More frequent updates, judging from a quick peek at hub.docker.com
- More TeX files compile out of the box, because it comes with a big library

Disadvantages:
- Docker image is ~10x the size

For me, I don't care about an extra minute of downloading but the LaTeX file I was trying to build didn't work with fredqi's lightweight image but found all the .sty files it needed in the texlive image.